### PR TITLE
Fixed Boost and x64 issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *build*/
 CMakeLists.txt.user
 *~
+*.bat

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,10 +55,13 @@ set(TURF_ALL_LIBRARY_DIRS "")
 
 # Optional: Locate Boost and append it to the list of include dirs/libraries.
 if(TURF_WITH_BOOST)
-    find_package(Boost REQUIRED)
+    add_definitions(-DBOOST_ALL_NO_LIB)
+    find_package(Boost REQUIRED system chrono thread atomic)
     list(APPEND TURF_ALL_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
     list(APPEND TURF_ALL_LIBRARIES ${Boost_LIBRARIES})
     list(APPEND TURF_ALL_LIBRARY_DIRS ${Boost_LIBRARY_DIRS})
+    
+    MESSAGE( STATUS "Boost_LIBRARIES: " ${Boost_LIBRARIES} )
 endif()
 
 # If this is the root listfile, add all samples

--- a/turf/impl/Affinity_Win32.h
+++ b/turf/impl/Affinity_Win32.h
@@ -37,16 +37,16 @@ public:
     }
 
     u32 getNumPhysicalCores() const {
-        return m_numPhysicalCores;
+        return static_cast<u32>(m_numPhysicalCores);
     }
 
     u32 getNumHWThreads() const {
-        return m_numHWThreads;
+        return static_cast<u32>(m_numHWThreads);
     }
 
     u32 getNumHWThreadsForCore(ureg core) const {
         TURF_ASSERT(core < m_numPhysicalCores);
-        return util::countSetBits(m_physicalCoreMasks[core]);
+        return static_cast<u32>(util::countSetBits(m_physicalCoreMasks[core]));
     }
 
     bool setAffinity(ureg core, ureg hwThread);

--- a/turf/impl/Atomic_Boost.h
+++ b/turf/impl/Atomic_Boost.h
@@ -32,9 +32,11 @@ inline void threadFenceSeqCst() { boost::atomic_thread_fence(boost::memory_order
 
 enum MemoryOrder {
     Relaxed = boost::memory_order_relaxed,
+    Consume = boost::memory_order_acquire,
     Acquire = boost::memory_order_acquire,
     Release = boost::memory_order_release,
-    AcqRel = boost::memory_order_acq_rel,
+    ConsumeRelease = boost::memory_order_acq_rel,
+    AcquireRelease = boost::memory_order_acq_rel,
 };
 
 template <typename T>

--- a/turf/impl/Mutex_Boost.h
+++ b/turf/impl/Mutex_Boost.h
@@ -31,7 +31,7 @@ public:
     }
 
     bool tryLock() {
-        return boost::mutex::tryLock();
+        return boost::mutex::try_lock();
     }
 
     void unlock() {
@@ -43,7 +43,7 @@ public:
 template <>
 class LockGuard<Mutex_Boost> : public boost::mutex::scoped_lock {
 public:
-    LockGuard_Boost(Mutex_Boost& mutex) : boost::mutex::scoped_lock(mutex) {
+    LockGuard(Mutex_Boost& mutex) : boost::mutex::scoped_lock(mutex) {
     }
 };
 


### PR DESCRIPTION
-Modified CMakeList to include only used boost libs. This fixed a linker issue with the visual studio generator.
-Fixed build warnings in Affinity_Win32 interface.
-Fixed errors in Atomic_Boost.h
-Fixed errors in Mutex_Boost.h
