### PR TITLE
Added thread local storage pointer

### DIFF
--- a/samples/SynchroTests/TLSPtrTester.cpp
+++ b/samples/SynchroTests/TLSPtrTester.cpp
@@ -1,0 +1,116 @@
+/*------------------------------------------------------------------------
+Turf: Configurable C++ platform adapter
+Copyright (c) 2016 Jeff Preshing and Bret Alfieri
+
+Distributed under the Simplified BSD License.
+Original location: https://github.com/preshing/turf
+
+This software is distributed WITHOUT ANY WARRANTY; without even the
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the LICENSE file for more information.
+------------------------------------------------------------------------*/
+
+#include <vector>
+#include <turf/Thread.h>
+#include <turf/TID.h>
+#include <turf/TLSPtr.h>
+
+using namespace turf::intTypes;
+
+//---------------------------------------------------------
+// TSLPtr Tester
+//---------------------------------------------------------
+class TLSPtrTester {
+private:
+    turf::TLSPtr<int> m_tlsPtr;
+    std::vector<int> m_tlsValuesByThreadNum;
+
+    struct TestStruct
+    {
+        int value;
+    };
+
+public:
+
+    struct ThreadParam {
+        int threadNum;
+        TLSPtrTester* pTester;
+    };
+
+    static turf::Thread::ReturnType TURF_THREAD_STARTCALL threadFunc(void* param) {
+        ThreadParam* threadParam = static_cast<ThreadParam*>(param);
+
+        int threadNum = threadParam->threadNum;
+        turf::TLSPtr<int>& tlsPtr = threadParam->pTester->m_tlsPtr;
+
+        tlsPtr.setData(new int(threadNum));
+
+        turf::Thread::sleepMillis(rand() % 100);
+
+        threadParam->pTester->m_tlsValuesByThreadNum[threadNum] = *tlsPtr;
+
+        delete threadParam;
+        return 0;
+    }
+
+    bool testInterface() {
+        const int TEST_VALUE = 5;
+
+        {
+            turf::TLSPtr<TestStruct> tlsPtr;
+        }
+        {
+            TestStruct* data = new TestStruct;
+            data->value = TEST_VALUE;
+
+            turf::TLSPtr<TestStruct> tlsPtr;
+            tlsPtr.setData(data);
+
+            if (data != tlsPtr.getData())
+                return false;
+
+            if (tlsPtr->value != TEST_VALUE)
+                return false;
+
+            if ((*tlsPtr).value != TEST_VALUE)
+                return false;
+        }
+
+        return true;
+    }
+
+    bool testFunctionality(int threadCount) {
+        m_tlsValuesByThreadNum.resize(threadCount);
+
+        std::vector<turf::Thread> threads(threadCount);
+        for (int ii = 0; ii < threadCount; ii++) {
+            ThreadParam* param = new ThreadParam;
+            param->threadNum = ii;
+            param->pTester = this;
+            threads[ii].run(&TLSPtrTester::threadFunc, param);
+        }
+        for (int ii = 0; ii < threadCount; ii++) {
+            threads[ii].join();
+        }
+
+        for (int ii = 0; ii < threadCount; ii++) {
+            if (m_tlsValuesByThreadNum[ii] != ii)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+bool testTLSPtr() {
+    TLSPtrTester tester;
+
+    if (!tester.testInterface())
+        return false;
+
+    if (!tester.testFunctionality(200))
+        return false;
+
+    return true;
+}

--- a/turf/TLSPtr.h
+++ b/turf/TLSPtr.h
@@ -1,0 +1,48 @@
+/*------------------------------------------------------------------------
+  Turf: Configurable C++ platform adapter
+  Copyright (c) 2016 Jeff Preshing and Bret Alfieri
+
+  Distributed under the Simplified BSD License.
+  Original location: https://github.com/preshing/turf
+
+  This software is distributed WITHOUT ANY WARRANTY; without even the
+  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the LICENSE file for more information.
+------------------------------------------------------------------------*/
+
+#ifndef TURF_TLS_PTR_H
+#define TURF_TLS_PTR_H
+
+#include <turf/Core.h>
+
+// clang-format off
+
+// Choose default implementation if not already configured by turf_userconfig.h:
+#if !defined(TURF_IMPL_TLS_PTR_PATH)
+    #if TURF_PREFER_BOOST
+        #define TURF_IMPL_TLS_PTR_PATH "impl/TLSPtr_Boost.h"
+        #define TURF_IMPL_TLS_PTR_TYPE turf::TLSPtr_Boost
+    #elif TURF_TARGET_WIN32
+        #define TURF_IMPL_TLS_PTR_PATH "impl/TLSPtr_Win32.h"
+        #define TURF_IMPL_TLS_PTR_TYPE turf::TLSPtr_Win32
+    #elif TURF_TARGET_POSIX
+        #define TURF_IMPL_TLS_PTR_PATH "impl/TLSPtr_POSIX.h"
+        #define TURF_IMPL_TLS_PTR_TYPE turf::TLSPtr_POSIX
+    #else
+        #define TURF_IMPL_TLS_PTR_PATH "*** Unable to select a default Thread implementation ***"
+    #endif
+#endif
+
+// Include the implementation:
+#include TURF_IMPL_TLS_PTR_PATH
+
+// Alias it:
+namespace turf {
+
+template<typename T>
+class TLSPtr : public TURF_IMPL_TLS_PTR_TYPE<T>
+{};
+
+}
+
+#endif // TURF_TLS_PTR_H

--- a/turf/impl/TLSPtr_Boost.h
+++ b/turf/impl/TLSPtr_Boost.h
@@ -1,0 +1,63 @@
+/*------------------------------------------------------------------------------
+  Turf: Configurable C++ platform adapter
+  Copyright (c) 2016 Jeff Preshing and Bret Alfieri
+
+  Distributed under the Simplified BSD License.
+  Original location: https://github.com/preshing/turf
+
+  This software is distributed WITHOUT ANY WARRANTY; without even the
+  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the LICENSE file for more information.
+------------------------------------------------------------------------------*/
+
+#ifndef TURF_IMPL_TLS_PTR_BOOST_H
+#define TURF_IMPL_TLS_PTR_BOOST_H
+
+#include <turf/Core.h>
+#include <turf/Assert.h>
+#include <boost/thread/tss.hpp>
+
+namespace turf {
+
+template<typename T>
+class TLSPtr_Boost {
+
+private:
+
+    boost::thread_specific_ptr<T> m_tssPtr;
+
+    // NOT COPYABLE
+    TLSPtr_Boost(const TLSPtr_Boost&);
+    TLSPtr_Boost& operator=(const TLSPtr_Boost&);
+
+public: // STRUCTORS
+
+    TLSPtr_Boost() : m_tssPtr(0) {
+    }
+
+public: // ACCESSORS
+
+    T* getData() const {
+        return m_tssPtr.get();
+    }
+
+    T* operator->() const {
+        return m_tssPtr.get();
+    }
+
+    T& operator*() const {
+        T* data = getData();
+        TURF_ASSERT(data);
+        return *data;
+    }
+
+public: // MUTATORS
+
+    void setData(T* value) {
+        m_tssPtr.reset(value);
+    }
+};
+
+} // namespace turf
+
+#endif // TURF_IMPL_TLS_PTR_BOOST_H

--- a/turf/impl/TLSPtr_POSIX.h
+++ b/turf/impl/TLSPtr_POSIX.h
@@ -1,0 +1,76 @@
+/*------------------------------------------------------------------------------
+  Turf: Configurable C++ platform adapter
+  Copyright (c) 2016 Jeff Preshing and Bret Alfieri
+
+  Distributed under the Simplified BSD License.
+  Original location: https://github.com/preshing/turf
+
+  This software is distributed WITHOUT ANY WARRANTY; without even the
+  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the LICENSE file for more information.
+------------------------------------------------------------------------------*/
+
+#ifndef TURF_IMPL_TLS_PTR_POSIX_H
+#define TURF_IMPL_TLS_PTR_POSIX_H
+
+#include <turf/Core.h>
+#include <turf/Assert.h>
+#include <pthread.h>
+
+namespace turf {
+
+template<typename T>
+class TLSPtr_POSIX {
+
+private:
+
+    pthread_key_t m_tlsKey;
+
+    // NOT COPYABLE
+    TLSPtr_POSIX(const TLSPtr_POSIX&);
+    TLSPtr_POSIX& operator=(const TLSPtr_POSIX&);
+
+public: // STRUCTORS
+
+    TLSPtr_POSIX() : m_tlsKey(0) {
+        int result = pthread_key_create(&m_tlsKey, NULL);
+        TURF_ASSERT(result == 0);
+    }
+
+    ~TLSPtr_POSIX() {
+        void* value = pthread_getspecific(m_tlsKey);
+        delete reinterpret_cast<T*>(value);
+        int result = pthread_key_delete(m_tlsKey);
+        TURF_ASSERT(result == 0);
+    }
+
+public: // ACCESSORS
+
+    T* getData() const {
+        void* value = pthread_getspecific(m_tlsKey);
+        return reinterpret_cast<T*>(value);
+    }
+
+    T* operator->() const {
+        return getData();
+    }
+
+    T& operator*() const {
+        T* data = getData();
+        TURF_ASSERT(data);
+        return *data;
+    }
+
+public: // MUTATORS
+
+    void setData(T* value) {
+        void* oldValue = pthread_getspecific(m_tlsKey);
+        delete reinterpret_cast<T*>(oldValue);
+        result = pthread_setspecific(m_tlsKey, value);
+        TURF_ASSERT(result == 0);
+    }
+};
+
+} // namespace turf
+
+#endif // TURF_IMPL_TLS_PTR_POSIX_H

--- a/turf/impl/TLSPtr_Win32.h
+++ b/turf/impl/TLSPtr_Win32.h
@@ -1,0 +1,77 @@
+/*------------------------------------------------------------------------------
+  Turf: Configurable C++ platform adapter
+  Copyright (c) 2016 Jeff Preshing and Bret Alfieri
+
+  Distributed under the Simplified BSD License.
+  Original location: https://github.com/preshing/turf
+
+  This software is distributed WITHOUT ANY WARRANTY; without even the
+  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the LICENSE file for more information.
+------------------------------------------------------------------------------*/
+
+#ifndef TURF_IMPL_TLS_PTR_WIN32_H
+#define TURF_IMPL_TLS_PTR_WIN32_H
+
+#include <turf/Core.h>
+#include <turf/Assert.h>
+
+namespace turf {
+
+template<typename T>
+class TLSPtr_Win32 {
+
+private:
+
+    DWORD m_tlsIndex;
+
+    // NOT COPYABLE
+    TLSPtr_Win32(const TLSPtr_Win32&);
+    TLSPtr_Win32& operator=(const TLSPtr_Win32&);
+
+public: // STRUCTORS
+
+    TLSPtr_Win32() {
+        m_tlsIndex = TlsAlloc();
+        TURF_ASSERT(m_tlsIndex != TLS_OUT_OF_INDEXES);
+    }
+
+    ~TLSPtr_Win32() {
+        LPVOID value = TlsGetValue(m_tlsIndex);
+        TURF_ASSERT(GetLastError() == ERROR_SUCCESS);
+        delete reinterpret_cast<T*>(value);
+        TlsFree(m_tlsIndex);
+    }
+
+public: // ACCESSORS
+
+    T* getData() const {
+        LPVOID value = TlsGetValue(m_tlsIndex);
+        TURF_ASSERT(GetLastError() == ERROR_SUCCESS);
+        return reinterpret_cast<T*>(value);
+    }
+
+    T* operator->() const {
+        return getData();
+    }
+
+    T& operator*() const {
+        return *getData();
+    }
+
+public: // MUTATORS
+
+    void setData(T* value) {
+        LPVOID oldValue = TlsGetValue(m_tlsIndex);
+        if (GetLastError() == ERROR_SUCCESS)
+        {
+            delete reinterpret_cast<T*>(oldValue);
+        }
+        BOOL result = TlsSetValue(m_tlsIndex, value);
+        TURF_ASSERT(result != 0);
+    }
+};
+
+} // namespace turf
+
+#endif // TURF_IMPL_TLS_PTR_WIN32_H


### PR DESCRIPTION
Added a thread local storage pointer abstraction that emulates boost
TSS. It is implemented for Win32, POSIX and boost.

It has been tested on Visual Studio with Win32 and Boost, and gcc on
Ubuntu with POSIX.
