### PR TITLE
Fix builds on linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ include_directories(${TURF_ALL_INCLUDE_DIRS})
 
 # Make installable.
 if(TURF_MAKE_INSTALLABLE)
-    install(TARGETS turf DESTINATION lib)
+  install(TARGETS turf DESTINATION ${LIB_INSTALL_DIR})
     install(DIRECTORY turf/ DESTINATION include/turf FILES_MATCHING PATTERN "*.h" PATTERN "*.inc")
     file(GLOB configHeaders "${CMAKE_CURRENT_BINARY_DIR}/include/*.h")
     install(FILES ${configHeaders} DESTINATION include)

--- a/turf/extra/JobDispatcher.h
+++ b/turf/extra/JobDispatcher.h
@@ -14,6 +14,7 @@
 #define TURF_EXTRA_JOBDISPATCHER_H
 
 #include <turf/Core.h>
+#include <turf/Assert.h>
 #include <turf/Affinity.h>
 #include <turf/extra/SpinKicker.h>
 #include <vector>


### PR DESCRIPTION
The Core/Assert.h file isn't included in JobDispatcher.h, this leads to
TURF_ASSERT not being defined. Also, libraries on linux should be
installed into ${LIB_INSTALL_DIR} instead of the hardcoded lib
directory. Systems like Fedora put 64 bit libraries in /usr/lib64
instead of /usr/lib, as is recommended in the Linux Filesystem
Heirarchy standard.
