### PR TITLE
fix: bump cmake_minimum_required to 3.5 for modern CMake compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 3.5)
 include(cmake/Macros.cmake)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)


### PR DESCRIPTION
## Summary

CMake 3.30+ removed support for `cmake_minimum_required` versions below 3.5. This causes a hard error when building Turf with any modern CMake:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

## Changes

- Bump `cmake_minimum_required(VERSION 2.8.5)` to `cmake_minimum_required(VERSION 3.5)` in the root `CMakeLists.txt`

## Motivation

Version 3.5 is the minimum that modern CMake still accepts. This is a no-op change for the actual build logic — Turf's CMakeLists.txt does not use any features that differ between 2.8.5 and 3.5.

This fix is needed by downstream projects that embed Turf as a submodule (via [Junction](https://github.com/preshing/junction)) and build with current system CMake. A companion PR has been submitted to Junction: https://github.com/preshing/junction/pull/55

## Testing

- Verified Turf builds cleanly with CMake 4.0.1 and GCC 15.2.0
- Successfully built giotto-ph wheels for Python 3.14.2 on Linux x86_64